### PR TITLE
feat: Domain 로직 구현

### DIFF
--- a/src/app/application/otherdvm.cpp
+++ b/src/app/application/otherdvm.cpp
@@ -1,0 +1,17 @@
+#include "otherdvm.h"
+#include <iostream>
+
+OtherDVM::OtherDVM(int id, const Location& loc)
+    : dvmId(id), location(loc) {}
+
+bool OtherDVM::findAvailableStocks(const std::string& itemCode) {
+    return true; // 임시
+}
+
+bool OtherDVM::askForPrepayment() {
+    return true; // 임시
+}
+
+const Location& OtherDVM::getLocation() const {
+    return location;
+}

--- a/src/app/application/otherdvm.h
+++ b/src/app/application/otherdvm.h
@@ -10,11 +10,11 @@ private:
     Location location;
 
 public:
-    OtherDVM(int id, Location loc);
-    bool findAvailableStocks();
+    OtherDVM(int id, const Location& loc);
+    bool findAvailableStocks(const std::string& itemCode);
     bool askForPrepayment();
-    Location getLocation();
-    int getDvmId();
+    const Location& getLocation() const;
+    int getDvmId() const;
 };
 
 #endif // OTHERDVM_H

--- a/src/app/application/sale.cpp
+++ b/src/app/application/sale.cpp
@@ -1,0 +1,70 @@
+#include "sale.h"
+#include <chrono>
+#include <ctime>
+#include <sstream>
+#include <stdexcept>
+
+// Helper 함수: 현재 시간을 문자열로 반환 (예: "2024-05-01 14:03:22")
+static std::string getCurrentTimeAsString() {
+    auto now = std::chrono::system_clock::now();
+    std::time_t timeNow = std::chrono::system_clock::to_time_t(now);
+    std::tm localTm;
+    localtime_r(&timeNow, &localTm);
+    char buffer[20];
+    std::strftime(buffer, sizeof(buffer), "%Y-%m-%d %H:%M:%S", &localTm);
+    return std::string(buffer);
+}
+
+// 일반 판매 요청 - 생성자
+Sale::Sale(SaleRequest request)
+    : item(request.item),
+      count(request.count),
+      totalAmount(request.totalAmount),
+      prepayment(nullptr) {
+
+    saleId = getCurrentTimeAsString();
+    datetime = getCurrentTimeAsString();
+
+    // 외부 결제 서버에 승인 요청
+}
+
+// 특정 DVM으로 향하는 선결제 요청 처리
+Sale::Sale(SaleRequest request, int targetDvmId)
+    : item(request.item),
+      count(request.count),
+      totalAmount(request.totalAmount) {
+    
+    saleId = getCurrentTimeAsString();
+    datetime = getCurrentTimeAsString();
+
+    // 외부 결제 서버
+
+    prepayment = new Prepayment(targetDvmId);
+}
+
+// 인증코드를 사용한 음료 수령 요청 처리
+Sale::Sale(SaleRequest request, const std::string& certCode)
+    : item(request.item),
+      count(request.count),
+      totalAmount(request.totalAmount) {
+
+    saleId = getCurrentTimeAsString();
+    datetime = getCurrentTimeAsString();
+
+    prepayment = new Prepayment(request.dvmId, CertificationCode(certCode));
+}
+
+
+// 수령 처리 메서드
+bool Sale::receivePrepaidItem(const std::string& certCode) {
+    if (!prepayment) return false;
+    return prepayment->isCertificationCode(certCode);
+}
+
+// 소멸자
+Sale::~Sale() {
+    if (prepayment != nullptr) {
+        delete prepayment;
+        prepayment = nullptr;
+    }
+}

--- a/src/app/application/sale.h
+++ b/src/app/application/sale.h
@@ -3,11 +3,16 @@
 
 #include <string>
 #include "../domain/item.h"
-#include "../domain/card.h"
 #include "../domain/prepayment.h"
 
-// Request 클래스 전방 선언
-class SaleRequest;
+// DTO
+struct SaleRequest {
+    Item item;
+    int count;
+    int totalAmount;
+    std::string cardNumber;
+    int dvmId;
+};
 
 class Sale {
 private:
@@ -16,7 +21,6 @@ private:
     Item item;
     int count;
     int totalAmount;
-    Card card;
     Prepayment* prepayment;
 
 public:
@@ -27,10 +31,12 @@ public:
     Sale(SaleRequest request, int targetDvmId);
     
     // 인증 코드를 사용한 판매 요청 처리
-    Sale(SaleRequest request, std::string certCode);
+    Sale(SaleRequest request, const std::string& certCode);
     
     // 선결제된 아이템 수령 처리
-    bool receivePrepaidItem(std::string certCode);
+    bool receivePrepaidItem(const std::string& certCode);
+
+    ~Sale();
 };
 
 #endif // SALE_H 

--- a/src/app/domain/card.cpp
+++ b/src/app/domain/card.cpp
@@ -1,0 +1,10 @@
+#include "card.h"
+#include <regex>
+
+Card::Card(std::string number) : cardNumber(number) {}
+
+// 올바른 카드 형식 4자리-4자리
+bool Card::isValid() {
+    std::regex cardFormat("^[0-9]{4}-[A-Za-z]{4}$");
+    return std::regex_match(cardNumber, cardFormat);
+}

--- a/src/app/domain/certificationcode.cpp
+++ b/src/app/domain/certificationcode.cpp
@@ -4,7 +4,7 @@
 
 CertificationCode::CertificationCode()
 {
-    // 랜덤 10자리 인증코드 생성
+    // 랜덤 5자리 인증코드 생성
     const std::string characters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
     const int codeLength = 5;
 
@@ -21,19 +21,15 @@ CertificationCode::CertificationCode()
     isUsed = false;
 }
 
-CertificationCode::CertificationCode(std::string value) : value(value), isUsed(false)
-{
-    // 외부에서 지정한 코드로 초기화 (특정 인증코드로 초기화)
-}
+// 외부에서 지정한 코드로 초기화 (특정 인증코드로 초기화)
+CertificationCode::CertificationCode(std::string value) 
+: value(value), isUsed(false) {}
 
-bool CertificationCode::markUsed()
+bool CertificationCode::markUsed(const std::string& certCode)
 {
-    if (isUsed)
-        return false;
+    if (isUsed) return false;
+    if(certCode != value) return false;
+
     isUsed = true;
     return true;
-}
-
-bool CertificationCode::matches(const std::string& inputCode) const {
-    return value == inputCode && !isUsed;
 }

--- a/src/app/domain/certificationcode.cpp
+++ b/src/app/domain/certificationcode.cpp
@@ -1,0 +1,39 @@
+#include "certificationcode.h"
+#include <random>
+#include <chrono>
+
+CertificationCode::CertificationCode()
+{
+    // 랜덤 10자리 인증코드 생성
+    const std::string characters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    const int codeLength = 5;
+
+    std::mt19937 rng(static_cast<unsigned int>(std::chrono::steady_clock::now().time_since_epoch().count()));
+    std::uniform_int_distribution<int> dist(0, characters.size() - 1);
+
+    value = "";
+
+    for (int i = 0; i < codeLength; ++i)
+    {
+        value += characters[dist(rng)];
+    }
+
+    isUsed = false;
+}
+
+CertificationCode::CertificationCode(std::string value) : value(value), isUsed(false)
+{
+    // 외부에서 지정한 코드로 초기화 (특정 인증코드로 초기화)
+}
+
+bool CertificationCode::markUsed()
+{
+    if (isUsed)
+        return false;
+    isUsed = true;
+    return true;
+}
+
+bool CertificationCode::matches(const std::string& inputCode) const {
+    return value == inputCode && !isUsed;
+}

--- a/src/app/domain/certificationcode.h
+++ b/src/app/domain/certificationcode.h
@@ -11,8 +11,7 @@ private:
 public:
     CertificationCode();
     CertificationCode(std::string value);
-    bool markUsed();
-    bool matches(const std::string& inputCode) const;
+    bool markUsed(const std::string& certCode);
 };
 
 #endif // CERTIFICATIONCODE_H

--- a/src/app/domain/certificationcode.h
+++ b/src/app/domain/certificationcode.h
@@ -12,6 +12,7 @@ public:
     CertificationCode();
     CertificationCode(std::string value);
     bool markUsed();
+    bool matches(const std::string& inputCode) const;
 };
 
 #endif // CERTIFICATIONCODE_H

--- a/src/app/domain/prepayment.cpp
+++ b/src/app/domain/prepayment.cpp
@@ -1,0 +1,15 @@
+#include "prepayment.h"
+
+// 인증코드 자동 생성
+Prepayment::Prepayment(int dvmId) : dvmId(dvmId), certCode() {
+    // 기본 생성자로 랜덤 인증코드 생성
+}
+
+// 외부에서 인증코드를 받는 경우
+Prepayment::Prepayment(int dvmId, CertificationCode certCode)
+    : dvmId(dvmId), certCode(certCode) {}
+
+// 인증코드 일치 여부 + 사용되지 않았는지 확인
+bool Prepayment::isCertificationCode(std::string inputCode) {
+    return certCode.matches(inputCode);
+}

--- a/src/app/domain/prepayment.cpp
+++ b/src/app/domain/prepayment.cpp
@@ -10,6 +10,6 @@ Prepayment::Prepayment(int dvmId, CertificationCode certCode)
     : dvmId(dvmId), certCode(certCode) {}
 
 // 인증코드 일치 여부 + 사용되지 않았는지 확인
-bool Prepayment::isCertificationCode(std::string inputCode) {
-    return certCode.matches(inputCode);
+bool Prepayment::isCertificationCode(const std::string& inputCertCode) {
+    return certCode.markUsed(inputCertCode);
 }

--- a/src/app/domain/prepayment.h
+++ b/src/app/domain/prepayment.h
@@ -8,7 +8,6 @@ class Prepayment {
 private:
     int dvmId;
     CertificationCode certCode;
-    int name;
 
 public:
     Prepayment(int dvmId);

--- a/src/app/domain/prepayment.h
+++ b/src/app/domain/prepayment.h
@@ -7,12 +7,13 @@
 class Prepayment {
 private:
     int dvmId;
-    std::string certCode;
+    CertificationCode certCode;
+    int name;
 
 public:
     Prepayment(int dvmId);
-    Prepayment(int dvmId, std::string certCode);
-    bool isCertificationCode();
+    Prepayment(int dvmId, CertificationCode certCode);
+    bool isCertificationCode(std::string inputCode);
 };
 
 #endif // PREPAYMENT_H

--- a/src/app/domain/prepayment.h
+++ b/src/app/domain/prepayment.h
@@ -12,7 +12,7 @@ private:
 public:
     Prepayment(int dvmId);
     Prepayment(int dvmId, CertificationCode certCode);
-    bool isCertificationCode(std::string inputCode);
+    bool isCertificationCode(const std::string& inputCertCode);
 };
 
 #endif // PREPAYMENT_H


### PR DESCRIPTION
**otherdvm**
: 현재 DVM과 다른 분산 자판기가 통신할 때 사용됨.
- _`findAvailableStocks`에 `itemCode` 인자로 전달해야 할 부분 추가했습니다._
- `findAvailableStocks`, `askForPrepayment`은 각각 다른 DVM에 특정 item 재고를 확인하는 것, 선결제 수락 여부 확인 등에 대한 함수인데, 실제 소켓 통신을 해야 하는 부분이라 임시로 `true` 반환 처리했습니다.
위 두 부분 맞게 구현한 건지 확인해주세요!

**sale**
: 결제, 선결제 요청, 인증코드를 통한 수령 로직
- 현재 외부 결제 서버 통신이 정의가 미흡하다고 생각해서,, 일단 주석으로 대체했습니다. -> 이 부분 또한 소켓 통신으로 진행되는 부분일까요?
- 회의 바탕으로 `SaleRequest` 을 struct로 선언해서 구현했습니다.
- _`SaleRequest`에 dvmId 추가했습니다. 선결제 요청 시에 필요하다고 판단되었습니다_

**card**
- card 도메인은 삭제되기로 했지만, `isValid`가 외부 결제 요청 전에 사용되므로 남겨두었습니다.
- 유효 기준을 UI 스토리 보드를 보고, "1234-ABCD" 형식의 카드 번호가 유효하다고 판단해서 구현해보았는데 맞는지 확인 부탁드립니담

**CertificationCode**
: 선결제 인증 코드를 담당하는 도메인 클래스
- 선결제 요청 시 자동 생성, 인증 코드 입력하면 한 번만 사용할 수 있도록 처리
- 랜덤 인증코드 생성 (영문 대소문자+숫자) 의 5자리 문자열

**Prepayment**
: 선결제 시에 인증 코드 생성, 수령 요청 시 검증하는 책임
- 첫번째 생성자 : certCode 기본 생성자 통해서 인증 코드 자동 생성 하도록
- 두번째 생성자 : 이미 발급된 인증코드 사용해서 수령 시 사용됨
- `isCertificationCode` -> certcode의 markUsed 호출해서 검증과 인증코드 사용 처리 함

---
제가 미처 고려하지 못한 부분도 있을 거고, 제대로 이해하지 못한 부분도 있을 수 있어서 리뷰 자유롭게 남겨주세요
